### PR TITLE
Add session persistence and remember-session login flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Android build artifacts
+android/.gradle/
+android/build/
+android/app/build/
+android/.idea/
+
+# OS files
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,83 @@
-# XUIManager
+# XUIManager Android
+
+XUIManager is a Jetpack Compose Android application for managing Xtream UI
+(XUI) reseller and administrator panels from a phone or tablet. After
+authenticating with your panel credentials the app surfaces the data and actions
+resellers rely on every day: customer subscriptions, reseller hierarchies,
+currently connected viewers, and live channel watcher counts. Renewals, ad-hoc
+API calls, and inline filtering tools make it easy to keep your panel organised
+without reaching for a desktop browser.
+
+## Feature highlights
+
+- **Secure login** – authenticate against your XUI instance, optionally enabling
+  HTTP logging to debug connectivity problems during development.
+- **Dashboard overview** – view resellers, subscriptions, online users, and
+  channel watcher statistics in dedicated cards with quick search and detail
+  dialogs.
+- **Powerful filtering** – limit subscriptions by status and channel watchers by
+  channel identifier without re-entering credentials.
+- **Renewals in seconds** – renew subscriptions for any number of months directly
+  from the dashboard.
+- **Custom API actions** – craft bespoke reseller API requests with multiple
+  parameters, send them on demand, and reuse the responses immediately.
+- **Clipboard friendly details** – inspect every field returned by the API and
+  copy the full payload to the clipboard for further analysis.
+- **Session persistence** – optionally remember the current token on-device so
+  the dashboard restores instantly the next time you launch the app.
+- **One tap refresh and logout** – refresh all dashboard data or clear the
+  session token from the top app bar.
+
+## Project structure
+
+The Android application lives entirely inside the [`android/`](android/)
+folder and is organised into a lightweight MVVM stack:
+
+- `data/` – Retrofit service definitions, repository logic, DataStore-backed
+  session persistence, and serialisable response models.
+- `ui/` – Jetpack Compose screens, widgets, and the `XuiViewModel` that powers
+  them.
+- `MainActivity` – entry point that wires the Compose UI to the view model.
+
+Networking uses Retrofit with Kotlin serialization for resilient parsing while
+OkHttp handles connectivity and optional logging.
+
+## Getting started
+
+1. Open the `android/` directory in Android Studio (Giraffe or newer).
+2. Allow the IDE to download the Android Gradle Plugin 8.1, Kotlin 1.9, and
+   Compose dependencies.
+3. Create a run configuration for the `app` module and deploy it to an emulator
+   or device running Android 7.0 (API 24) or later.
+
+Alternatively, build from the command line using the Gradle wrapper:
+
+```bash
+cd android
+./gradlew assembleDebug
+```
+
+## Usage tips
+
+- Enter the base URL to your reseller portal exactly as you would in a browser.
+  The app automatically normalises missing schemes and trailing slashes.
+- Enable request logging from the login screen if you need to inspect the raw
+  HTTP traffic in Logcat.
+- Toggle **Remember session** to store the authenticated token securely using
+  DataStore so you can jump straight back to the dashboard after closing the
+  app.
+- Tap any list item to open a detail dialog. Use the **Copy data** button to
+  place the formatted payload on the clipboard.
+- The custom action card accepts multiple key/value pairs. Use it to call
+  lesser-used reseller API actions without leaving the app.
+- Pull-to-refresh style updates are handled by the refresh icon in the top app
+  bar.
+
+> **Note:** Available actions and field names depend on your specific XUI
+> deployment. Consult your panel's documentation for the full reseller API
+> reference.
+
+## Contributing
+
+Issues and pull requests are welcome! Please describe the XUI endpoint you are
+integrating with so we can reproduce any problems quickly.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,0 +1,83 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.serialization")
+}
+
+android {
+    namespace = "com.xuimanager.app"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.xuimanager.app"
+        minSdk = 24
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        vectorDrawables.useSupportLibrary = true
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    buildFeatures {
+        compose = true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.3"
+    }
+
+    packaging {
+        resources {
+            excludes += "/META-INF/{AL2.0,LGPL2.1}"
+        }
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.2")
+    implementation("androidx.activity:activity-compose:1.7.2")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.6.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
+    implementation("androidx.datastore:datastore-preferences:1.0.0")
+    implementation("com.squareup.retrofit2:retrofit:2.9.0")
+    implementation("com.squareup.okhttp3:logging-interceptor:4.11.0")
+    implementation("com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:0.8.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0")
+
+    val composeBom = platform("androidx.compose:compose-bom:2023.10.01")
+    implementation(composeBom)
+    androidTestImplementation(composeBom)
+
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.navigation:navigation-compose:2.7.3")
+
+    debugImplementation("androidx.compose.ui:ui-tooling")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
+
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+}

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Placeholder rules for release builds. Add keep rules when enabling minification.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.XUIManager">
+        <activity
+            android:name="com.xuimanager.app.MainActivity"
+            android:exported="true"
+            android:windowSoftInputMode="adjustResize">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/android/app/src/main/java/com/xuimanager/app/MainActivity.kt
+++ b/android/app/src/main/java/com/xuimanager/app/MainActivity.kt
@@ -1,0 +1,30 @@
+package com.xuimanager.app
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.compose.material3.Surface
+import androidx.compose.material3.MaterialTheme
+import com.xuimanager.app.ui.XuiManagerApp
+import com.xuimanager.app.ui.XuiViewModel
+import com.xuimanager.app.ui.XuiViewModelFactory
+import com.xuimanager.app.data.SessionPreferences
+
+class MainActivity : ComponentActivity() {
+    private val sessionPreferences by lazy { SessionPreferences(applicationContext) }
+    private val viewModel: XuiViewModel by viewModels {
+        XuiViewModelFactory(sessionPreferences)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            MaterialTheme {
+                Surface(color = MaterialTheme.colorScheme.background) {
+                    XuiManagerApp(viewModel = viewModel)
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/xuimanager/app/data/Models.kt
+++ b/android/app/src/main/java/com/xuimanager/app/data/Models.kt
@@ -1,0 +1,81 @@
+package com.xuimanager.app.data
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+
+@Serializable
+data class LoginResponse(
+    val status: Int,
+    val message: String? = null,
+    val token: String? = null,
+    @SerialName("admin_id") val adminId: Int? = null,
+    val username: String? = null
+)
+
+@Serializable
+data class ResellerEnvelope(
+    val status: Int,
+    val message: String? = null,
+    val resellers: List<JsonObject> = emptyList()
+)
+
+@Serializable
+data class SubscriptionEnvelope(
+    val status: Int,
+    val message: String? = null,
+    val subscriptions: List<JsonObject> = emptyList()
+)
+
+@Serializable
+data class OnlineUsersEnvelope(
+    val status: Int,
+    val message: String? = null,
+    val users: List<JsonObject> = emptyList()
+)
+
+@Serializable
+data class ChannelWatchersEnvelope(
+    val status: Int,
+    val message: String? = null,
+    val channels: List<JsonObject> = emptyList()
+)
+
+@Serializable
+data class RenewResponse(
+    val status: Int,
+    val message: String? = null,
+    @SerialName("subscription_id") val subscriptionId: Int? = null
+)
+
+@Serializable
+data class GenericEnvelope(
+    val status: Int,
+    val message: String? = null,
+    val error: String? = null,
+    val token: String? = null,
+    val data: JsonElement? = null
+)
+
+data class DisplayEntry(
+    val title: String,
+    val attributes: List<Pair<String, String>>
+) {
+    companion object {
+        fun fromJson(json: JsonObject): DisplayEntry {
+            val title = json["username"]?.toPrimitiveString()
+                ?: json["name"]?.toPrimitiveString()
+                ?: json["title"]?.toPrimitiveString()
+                ?: json["id"]?.toPrimitiveString()
+                ?: "Entry"
+            val pairs = json.entries.map { (key, value) -> key to value.toPrimitiveString() }
+            return DisplayEntry(title = title, attributes = pairs)
+        }
+    }
+}
+
+private fun JsonElement.toPrimitiveString(): String = when (this) {
+    is JsonObject -> this.toString()
+    else -> this.toString().trim('"')
+}

--- a/android/app/src/main/java/com/xuimanager/app/data/SessionPreferences.kt
+++ b/android/app/src/main/java/com/xuimanager/app/data/SessionPreferences.kt
@@ -1,0 +1,94 @@
+package com.xuimanager.app.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private const val DATA_STORE_NAME = "xui_session"
+
+private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = DATA_STORE_NAME)
+
+class SessionPreferences(context: Context) {
+    private val appContext = context.applicationContext
+    private val dataStore = appContext.dataStore
+
+    val data: Flow<SessionPreferencesState> = dataStore.data.map { prefs ->
+        SessionPreferencesState(
+            baseUrl = prefs[Keys.BASE_URL] ?: "",
+            username = prefs[Keys.USERNAME] ?: "",
+            enableLogging = prefs[Keys.ENABLE_LOGGING] ?: false,
+            rememberSession = prefs[Keys.REMEMBER_SESSION] ?: false,
+            token = prefs[Keys.TOKEN],
+            adminId = prefs[Keys.ADMIN_ID]
+        )
+    }
+
+    suspend fun persistLogin(
+        baseUrl: String,
+        username: String,
+        enableLogging: Boolean,
+        rememberSession: Boolean,
+        token: String?,
+        adminId: Int?
+    ) {
+        dataStore.edit { prefs ->
+            prefs[Keys.BASE_URL] = baseUrl
+            prefs[Keys.USERNAME] = username
+            prefs[Keys.ENABLE_LOGGING] = enableLogging
+            prefs[Keys.REMEMBER_SESSION] = rememberSession
+            if (rememberSession && !token.isNullOrBlank()) {
+                prefs[Keys.TOKEN] = token
+                if (adminId != null) {
+                    prefs[Keys.ADMIN_ID] = adminId
+                } else {
+                    prefs.remove(Keys.ADMIN_ID)
+                }
+            } else {
+                prefs.remove(Keys.TOKEN)
+                prefs.remove(Keys.ADMIN_ID)
+            }
+        }
+    }
+
+    suspend fun updateRememberSession(remember: Boolean) {
+        dataStore.edit { prefs ->
+            prefs[Keys.REMEMBER_SESSION] = remember
+            if (!remember) {
+                prefs.remove(Keys.TOKEN)
+                prefs.remove(Keys.ADMIN_ID)
+            }
+        }
+    }
+
+    suspend fun clearToken() {
+        dataStore.edit { prefs ->
+            prefs.remove(Keys.TOKEN)
+            prefs.remove(Keys.ADMIN_ID)
+        }
+    }
+
+    private object Keys {
+        val BASE_URL: Preferences.Key<String> = stringPreferencesKey("base_url")
+        val USERNAME: Preferences.Key<String> = stringPreferencesKey("username")
+        val ENABLE_LOGGING: Preferences.Key<Boolean> = booleanPreferencesKey("enable_logging")
+        val REMEMBER_SESSION: Preferences.Key<Boolean> = booleanPreferencesKey("remember_session")
+        val TOKEN: Preferences.Key<String> = stringPreferencesKey("token")
+        val ADMIN_ID: Preferences.Key<Int> = intPreferencesKey("admin_id")
+    }
+}
+
+data class SessionPreferencesState(
+    val baseUrl: String,
+    val username: String,
+    val enableLogging: Boolean,
+    val rememberSession: Boolean,
+    val token: String?,
+    val adminId: Int?
+)

--- a/android/app/src/main/java/com/xuimanager/app/data/XuiRepository.kt
+++ b/android/app/src/main/java/com/xuimanager/app/data/XuiRepository.kt
@@ -1,0 +1,124 @@
+package com.xuimanager.app.data
+
+import kotlinx.serialization.SerializationException
+import retrofit2.HttpException
+import java.io.IOException
+
+class XuiRepository(private val service: XuiService) {
+    private var token: String? = null
+
+    suspend fun login(username: String, password: String): LoginResult = safeCall {
+        val response = service.login(username = username, password = password)
+        if (response.status != 1 || response.token.isNullOrBlank()) {
+            val message = response.message ?: "Login failed"
+            throw XuiRepositoryException(message)
+        }
+        token = response.token
+        LoginResult(
+            token = response.token,
+            adminId = response.adminId,
+            username = response.username
+        )
+    }
+
+    suspend fun fetchResellers(): List<DisplayEntry> = safeCall {
+        val result = service.getResellers(token = requireToken())
+        if (result.status != 1) {
+            throw XuiRepositoryException(result.message ?: "Unable to load resellers")
+        }
+        result.resellers.map { DisplayEntry.fromJson(it) }
+    }
+
+    suspend fun fetchSubscriptions(status: String?): List<DisplayEntry> = safeCall {
+        val result = service.getSubscriptions(token = requireToken(), status = status?.ifBlank { null })
+        if (result.status != 1) {
+            throw XuiRepositoryException(result.message ?: "Unable to load subscriptions")
+        }
+        result.subscriptions.map { DisplayEntry.fromJson(it) }
+    }
+
+    suspend fun renewSubscription(subscriptionId: Int, months: Int): RenewResult = safeCall {
+        val safeMonths = months.coerceAtLeast(1)
+        val result = service.renewSubscription(
+            token = requireToken(),
+            subscriptionId = subscriptionId,
+            months = safeMonths
+        )
+        if (result.status != 1) {
+            throw XuiRepositoryException(result.message ?: "Renewal failed")
+        }
+        RenewResult(message = result.message ?: "Subscription renewed", subscriptionId = result.subscriptionId)
+    }
+
+    suspend fun fetchOnlineUsers(): List<DisplayEntry> = safeCall {
+        val result = service.getOnlineUsers(token = requireToken())
+        if (result.status != 1) {
+            throw XuiRepositoryException(result.message ?: "Unable to load online users")
+        }
+        result.users.map { DisplayEntry.fromJson(it) }
+    }
+
+    suspend fun fetchChannelWatchers(channelId: Int?): List<DisplayEntry> = safeCall {
+        val result = service.getChannelWatchers(token = requireToken(), channelId = channelId)
+        if (result.status != 1) {
+            throw XuiRepositoryException(result.message ?: "Unable to load channel watchers")
+        }
+        result.channels.map { DisplayEntry.fromJson(it) }
+    }
+
+    suspend fun runCustomAction(params: Map<String, String>): GenericResult = safeCall {
+        val action = params["action"]?.trim()?.takeIf { it.isNotBlank() }
+            ?: throw XuiRepositoryException("Action name is required")
+        val payload = params.toMutableMap().apply {
+            this["action"] = action
+            this["token"] = requireToken()
+        }
+        val result = service.customAction(payload)
+        if (result.status != 1) {
+            throw XuiRepositoryException(result.message ?: result.error ?: "Custom action failed")
+        }
+        GenericResult(message = result.message, token = result.token)
+    }
+
+    fun clearToken() {
+        token = null
+    }
+
+    fun restoreToken(existingToken: String) {
+        token = existingToken
+    }
+
+    private fun requireToken(): String = token ?: throw IllegalStateException("Not authenticated")
+
+    private suspend fun <T> safeCall(block: suspend () -> T): T {
+        return try {
+            block()
+        } catch (ex: XuiRepositoryException) {
+            throw ex
+        } catch (ex: HttpException) {
+            throw XuiRepositoryException("Server error ${ex.code()}")
+        } catch (ex: SerializationException) {
+            throw XuiRepositoryException("Failed to parse server response")
+        } catch (ex: IOException) {
+            throw XuiRepositoryException(ex.message ?: "Network error, please check your connection")
+        }
+    }
+}
+
+data class LoginResult(
+    val token: String,
+    val adminId: Int?,
+    val username: String?
+)
+
+data class RenewResult(
+    val message: String,
+    val subscriptionId: Int?
+)
+
+data class GenericResult(
+    val message: String?,
+    val token: String?
+)
+
+class XuiRepositoryException(message: String) : Exception(message)

--- a/android/app/src/main/java/com/xuimanager/app/data/XuiService.kt
+++ b/android/app/src/main/java/com/xuimanager/app/data/XuiService.kt
@@ -1,0 +1,108 @@
+package com.xuimanager.app.data
+
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
+import retrofit2.http.Field
+import retrofit2.http.FieldMap
+import retrofit2.http.FormUrlEncoded
+import retrofit2.http.POST
+import java.util.concurrent.TimeUnit
+import okhttp3.MediaType.Companion.toMediaType
+
+interface XuiService {
+    @FormUrlEncoded
+    @POST("reseller_api.php")
+    suspend fun login(
+        @Field("action") action: String = "login",
+        @Field("username") username: String,
+        @Field("password") password: String
+    ): LoginResponse
+
+    @FormUrlEncoded
+    @POST("reseller_api.php")
+    suspend fun getResellers(
+        @Field("action") action: String = "get_resellers",
+        @Field("token") token: String
+    ): ResellerEnvelope
+
+    @FormUrlEncoded
+    @POST("reseller_api.php")
+    suspend fun getSubscriptions(
+        @Field("action") action: String = "get_subscriptions",
+        @Field("token") token: String,
+        @Field("status") status: String? = null
+    ): SubscriptionEnvelope
+
+    @FormUrlEncoded
+    @POST("reseller_api.php")
+    suspend fun renewSubscription(
+        @Field("action") action: String = "renew_subscription",
+        @Field("token") token: String,
+        @Field("subscription_id") subscriptionId: Int,
+        @Field("months") months: Int
+    ): RenewResponse
+
+    @FormUrlEncoded
+    @POST("reseller_api.php")
+    suspend fun getOnlineUsers(
+        @Field("action") action: String = "get_online_users",
+        @Field("token") token: String
+    ): OnlineUsersEnvelope
+
+    @FormUrlEncoded
+    @POST("reseller_api.php")
+    suspend fun getChannelWatchers(
+        @Field("action") action: String = "get_channel_watchers",
+        @Field("token") token: String,
+        @Field("channel_id") channelId: Int? = null
+    ): ChannelWatchersEnvelope
+
+    @FormUrlEncoded
+    @POST("reseller_api.php")
+    suspend fun customAction(
+        @FieldMap params: Map<String, String>
+    ): GenericEnvelope
+}
+
+object XuiServiceFactory {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        encodeDefaults = false
+    }
+
+    fun create(rawBaseUrl: String, enableLogging: Boolean = false): XuiService {
+        val logging = HttpLoggingInterceptor().apply {
+            level = if (enableLogging) HttpLoggingInterceptor.Level.BODY else HttpLoggingInterceptor.Level.NONE
+        }
+
+        val client = OkHttpClient.Builder()
+            .addInterceptor(logging)
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .build()
+
+        val contentType = "application/json".toMediaType()
+
+        return Retrofit.Builder()
+            .baseUrl(sanitiseBaseUrl(rawBaseUrl))
+            .addConverterFactory(json.asConverterFactory(contentType))
+            .client(client)
+            .build()
+            .create(XuiService::class.java)
+    }
+
+    private fun sanitiseBaseUrl(baseUrl: String): String {
+        var working = baseUrl.trim()
+        if (!working.startsWith("http://") && !working.startsWith("https://")) {
+            working = "https://$working"
+        }
+        if (!working.endsWith('/')) {
+            working += '/'
+        }
+        return working
+    }
+}

--- a/android/app/src/main/java/com/xuimanager/app/ui/XuiManagerApp.kt
+++ b/android/app/src/main/java/com/xuimanager/app/ui/XuiManagerApp.kt
@@ -1,0 +1,646 @@
+package com.xuimanager.app.ui
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material.icons.filled.Logout
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberSnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import com.xuimanager.app.data.DisplayEntry
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun XuiManagerApp(viewModel: XuiViewModel) {
+    val state = viewModel.uiState
+    val snackbarHostState = rememberSnackbarHostState()
+
+    LaunchedEffect(state.error) {
+        state.error?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.clearError()
+        }
+    }
+
+    LaunchedEffect(state.successMessage) {
+        state.successMessage?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.clearSuccessMessage()
+        }
+    }
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
+        topBar = {
+            if (state.loginResult != null) {
+                TopAppBar(
+                    title = { Text(text = "XUI Manager") },
+                    actions = {
+                        IconButton(onClick = { viewModel.refreshAll() }, enabled = !state.isLoading) {
+                            Icon(imageVector = Icons.Default.Refresh, contentDescription = "Refresh data")
+                        }
+                        IconButton(onClick = viewModel::logout) {
+                            Icon(imageVector = Icons.Default.Logout, contentDescription = "Logout")
+                        }
+                    }
+                )
+            }
+        }
+    ) { padding ->
+        if (state.loginResult == null) {
+            LoginScreen(
+                modifier = Modifier
+                    .padding(padding)
+                    .fillMaxSize(),
+                form = state.loginForm,
+                isLoading = state.isLoading,
+                onBaseUrlChanged = viewModel::updateBaseUrl,
+                onUsernameChanged = viewModel::updateUsername,
+                onLoggingChanged = viewModel::updateLoggingPreference,
+                onRememberChanged = viewModel::updateRememberSession,
+                onLogin = viewModel::login
+            )
+        } else {
+            DashboardScreen(
+                modifier = Modifier
+                    .padding(padding)
+                    .fillMaxSize(),
+                state = state,
+                onRenew = viewModel::renewSubscription,
+                onStatusChanged = viewModel::updateSubscriptionStatus,
+                onChannelFilterChanged = viewModel::updateChannelFilter,
+                onCustomAction = viewModel::runCustomAction
+            )
+        }
+    }
+}
+
+@Composable
+private fun LoginScreen(
+    modifier: Modifier,
+    form: LoginFormState,
+    isLoading: Boolean,
+    onBaseUrlChanged: (String) -> Unit,
+    onUsernameChanged: (String) -> Unit,
+    onLoggingChanged: (Boolean) -> Unit,
+    onRememberChanged: (Boolean) -> Unit,
+    onLogin: (baseUrl: String, username: String, password: String, enableLogging: Boolean) -> Unit
+) {
+    var password by rememberSaveable { mutableStateOf("") }
+    var showPassword by rememberSaveable { mutableStateOf(false) }
+
+    Column(
+        modifier = modifier.padding(24.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(text = "Sign in to your XUI panel", style = MaterialTheme.typography.titleLarge)
+        Spacer(modifier = Modifier.height(24.dp))
+        OutlinedTextField(
+            value = form.baseUrl,
+            onValueChange = onBaseUrlChanged,
+            label = { Text("Panel URL") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            placeholder = { Text("https://example.com/") }
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        OutlinedTextField(
+            value = form.username,
+            onValueChange = onUsernameChanged,
+            label = { Text("Username") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        OutlinedTextField(
+            value = password,
+            onValueChange = { password = it },
+            label = { Text("Password") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            visualTransformation = if (showPassword) VisualTransformation.None else PasswordVisualTransformation(),
+            trailingIcon = {
+                TextButton(onClick = { showPassword = !showPassword }) {
+                    Text(if (showPassword) "Hide" else "Show")
+                }
+            }
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Switch(
+                checked = form.enableLogging,
+                onCheckedChange = onLoggingChanged
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(text = "Enable request logging")
+        }
+        Spacer(modifier = Modifier.height(12.dp))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Checkbox(checked = form.rememberSession, onCheckedChange = onRememberChanged)
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(text = "Remember session on this device")
+        }
+        Spacer(modifier = Modifier.height(24.dp))
+        Button(
+            onClick = { onLogin(form.baseUrl.trim(), form.username.trim(), password, form.enableLogging) },
+            enabled = !isLoading && form.baseUrl.isNotBlank() && form.username.isNotBlank() && password.isNotBlank(),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            if (isLoading) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(20.dp),
+                    strokeWidth = 2.dp
+                )
+                Spacer(modifier = Modifier.width(12.dp))
+            }
+            Text("Login")
+        }
+    }
+}
+
+@Composable
+private fun DashboardScreen(
+    modifier: Modifier,
+    state: XuiUiState,
+    onRenew: (subscriptionId: Int, months: Int) -> Unit,
+    onStatusChanged: (String?) -> Unit,
+    onChannelFilterChanged: (String?) -> Unit,
+    onCustomAction: (Map<String, String>) -> Unit
+) {
+    var selectedEntry by remember { mutableStateOf<DisplayEntry?>(null) }
+
+    LazyColumn(
+        modifier = modifier.padding(horizontal = 16.dp),
+        contentPadding = PaddingValues(vertical = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        item {
+            Text(
+                text = "Welcome ${state.loginResult?.username ?: "reseller"}",
+                style = MaterialTheme.typography.titleLarge
+            )
+        }
+        item {
+            FiltersCard(
+                status = state.subscriptionStatus.orEmpty(),
+                channelId = state.channelFilter.orEmpty(),
+                onStatusChanged = onStatusChanged,
+                onChannelFilterChanged = onChannelFilterChanged
+            )
+        }
+        item {
+            RenewSubscriptionCard(onRenew = onRenew, isProcessing = state.isRenewing)
+        }
+        item {
+            CustomActionCard(onCustomAction = onCustomAction, isProcessing = state.isLoading)
+        }
+        item {
+            DataSection(
+                title = "Resellers",
+                entries = state.resellers,
+                emptyLabel = "No resellers available",
+                onEntrySelected = { selectedEntry = it }
+            )
+        }
+        item {
+            DataSection(
+                title = "Subscriptions",
+                entries = state.subscriptions,
+                emptyLabel = "No subscriptions found",
+                onEntrySelected = { selectedEntry = it }
+            )
+        }
+        item {
+            DataSection(
+                title = "Online Users",
+                entries = state.onlineUsers,
+                emptyLabel = "No active viewers",
+                onEntrySelected = { selectedEntry = it }
+            )
+        }
+        item {
+            DataSection(
+                title = "Channel Watchers",
+                entries = state.channelWatchers,
+                emptyLabel = "No channel watcher data",
+                onEntrySelected = { selectedEntry = it }
+            )
+        }
+        if (state.isLoading) {
+            item {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+        }
+    }
+
+    selectedEntry?.let { entry ->
+        EntryDetailDialog(entry = entry, onDismiss = { selectedEntry = null })
+    }
+}
+
+@Composable
+private fun FiltersCard(
+    status: String,
+    channelId: String,
+    onStatusChanged: (String?) -> Unit,
+    onChannelFilterChanged: (String?) -> Unit
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(text = "Filters", style = MaterialTheme.typography.titleMedium)
+            Spacer(modifier = Modifier.height(12.dp))
+            OutlinedTextField(
+                value = status,
+                onValueChange = { onStatusChanged(it) },
+                label = { Text("Subscription status (e.g. active)") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            OutlinedTextField(
+                value = channelId,
+                onValueChange = { onChannelFilterChanged(it) },
+                label = { Text("Channel ID filter") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true
+            )
+        }
+    }
+}
+
+@Composable
+private fun RenewSubscriptionCard(
+    onRenew: (subscriptionId: Int, months: Int) -> Unit,
+    isProcessing: Boolean
+) {
+    var subscriptionId by remember { mutableStateOf("") }
+    var months by remember { mutableStateOf("1") }
+
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(text = "Renew subscription", style = MaterialTheme.typography.titleMedium)
+            Spacer(modifier = Modifier.height(12.dp))
+            OutlinedTextField(
+                value = subscriptionId,
+                onValueChange = { subscriptionId = it },
+                label = { Text("Subscription ID") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            OutlinedTextField(
+                value = months,
+                onValueChange = { months = it },
+                label = { Text("Months") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(
+                onClick = {
+                    val id = subscriptionId.toIntOrNull()
+                    val duration = months.toIntOrNull() ?: 1
+                    if (id != null) {
+                        onRenew(id, duration)
+                    }
+                },
+                enabled = !isProcessing && subscriptionId.isNotBlank(),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                if (isProcessing) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(20.dp),
+                        strokeWidth = 2.dp
+                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                }
+                Text("Renew")
+            }
+        }
+    }
+}
+
+@Composable
+private fun CustomActionCard(
+    onCustomAction: (Map<String, String>) -> Unit,
+    isProcessing: Boolean
+) {
+    var action by remember { mutableStateOf("") }
+    val parameters = remember { mutableStateListOf(CustomParam(id = 0)) }
+    var nextId by remember { mutableIntStateOf(1) }
+
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(text = "Custom API action", style = MaterialTheme.typography.titleMedium)
+            Spacer(modifier = Modifier.height(12.dp))
+            OutlinedTextField(
+                value = action,
+                onValueChange = { action = it },
+                label = { Text("Action name") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            parameters.forEachIndexed { index, param ->
+                ParameterRow(
+                    parameter = param,
+                    onChange = { updated -> parameters[index] = updated },
+                    onRemove = {
+                        if (parameters.size == 1) {
+                            parameters[index] = CustomParam(id = param.id)
+                        } else {
+                            parameters.removeAt(index)
+                        }
+                    }
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+            TextButton(onClick = {
+                parameters.add(CustomParam(id = nextId))
+                nextId++
+            }) {
+                Icon(imageVector = Icons.Default.Add, contentDescription = "Add parameter")
+                Spacer(modifier = Modifier.width(6.dp))
+                Text("Add parameter")
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                Button(
+                    onClick = {
+                        val payload = buildMap {
+                            put("action", action.trim())
+                            parameters
+                                .mapNotNull { param ->
+                                    val key = param.key.trim()
+                                    val value = param.value.trim()
+                                    if (key.isNotEmpty() && value.isNotEmpty()) key to value else null
+                                }
+                                .forEach { (key, value) -> put(key, value) }
+                        }
+                        onCustomAction(payload)
+                    },
+                    enabled = !isProcessing && action.isNotBlank()
+                ) {
+                    Text("Send")
+                }
+                TextButton(onClick = {
+                    action = ""
+                    parameters.clear()
+                    parameters.add(CustomParam(id = 0))
+                    nextId = 1
+                }) {
+                    Text("Clear")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ParameterRow(
+    parameter: CustomParam,
+    onChange: (CustomParam) -> Unit,
+    onRemove: () -> Unit
+) {
+    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+        OutlinedTextField(
+            value = parameter.key,
+            onValueChange = { onChange(parameter.copy(key = it)) },
+            label = { Text("Key") },
+            modifier = Modifier.weight(1f),
+            singleLine = true
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        OutlinedTextField(
+            value = parameter.value,
+            onValueChange = { onChange(parameter.copy(value = it)) },
+            label = { Text("Value") },
+            modifier = Modifier.weight(1f),
+            singleLine = true
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        IconButton(onClick = onRemove) {
+            Icon(imageVector = Icons.Default.Close, contentDescription = "Remove parameter")
+        }
+    }
+}
+
+@Composable
+private fun DataSection(
+    title: String,
+    entries: List<DisplayEntry>,
+    emptyLabel: String,
+    onEntrySelected: (DisplayEntry) -> Unit
+) {
+    var expanded by remember { mutableStateOf(true) }
+    var query by remember { mutableStateOf("") }
+    val filteredEntries = remember(query, entries) {
+        if (query.isBlank()) {
+            entries
+        } else {
+            entries.filter { entry ->
+                entry.title.contains(query, ignoreCase = true) ||
+                    entry.attributes.any { (label, value) ->
+                        label.contains(query, ignoreCase = true) ||
+                            value.contains(query, ignoreCase = true)
+                    }
+            }
+        }
+    }
+    val displayEntries = filteredEntries.take(50)
+    val overflowCount = filteredEntries.size - displayEntries.size
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+                Text(text = title, style = MaterialTheme.typography.titleMedium)
+                Spacer(modifier = Modifier.weight(1f))
+                IconButton(onClick = { expanded = !expanded }) {
+                    Icon(
+                        imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                        contentDescription = if (expanded) "Collapse" else "Expand"
+                    )
+                }
+            }
+            AnimatedVisibility(visible = expanded) {
+                Column {
+                    Spacer(modifier = Modifier.height(12.dp))
+                    OutlinedTextField(
+                        value = query,
+                        onValueChange = { query = it },
+                        label = { Text("Search") },
+                        modifier = Modifier.fillMaxWidth(),
+                        singleLine = true,
+                        trailingIcon = {
+                            if (query.isNotBlank()) {
+                                IconButton(onClick = { query = "" }) {
+                                    Icon(imageVector = Icons.Default.Close, contentDescription = "Clear search")
+                                }
+                            } else {
+                                Icon(imageVector = Icons.Default.Search, contentDescription = "Search entries")
+                            }
+                        }
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                    if (displayEntries.isEmpty()) {
+                        Text(emptyLabel, style = MaterialTheme.typography.bodyMedium)
+                    } else {
+                        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                            displayEntries.forEach { entry ->
+                                EntryListItem(entry = entry, onClick = onEntrySelected)
+                            }
+                            if (overflowCount > 0) {
+                                Text(
+                                    text = "+$overflowCount more – refine your search to narrow the list",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun EntryListItem(entry: DisplayEntry, onClick: (DisplayEntry) -> Unit) {
+    Card(
+        onClick = { onClick(entry) },
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Text(text = entry.title, style = MaterialTheme.typography.titleSmall)
+            Spacer(modifier = Modifier.height(4.dp))
+            entry.attributes.take(3).forEach { (label, value) ->
+                Text(
+                    text = "$label: $value",
+                    style = MaterialTheme.typography.bodySmall
+                )
+            }
+            if (entry.attributes.size > 3) {
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "+${entry.attributes.size - 3} more fields",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.primary
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun EntryDetailDialog(entry: DisplayEntry, onDismiss: () -> Unit) {
+    val clipboardManager = LocalClipboardManager.current
+    val scrollState = rememberScrollState()
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Close")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = {
+                val formatted = buildString {
+                    appendLine(entry.title)
+                    entry.attributes.forEach { (label, value) ->
+                        appendLine("$label: $value")
+                    }
+                }.trimEnd()
+                clipboardManager.setText(AnnotatedString(formatted))
+            }) {
+                Icon(imageVector = Icons.Default.ContentCopy, contentDescription = "Copy entry")
+                Spacer(modifier = Modifier.width(6.dp))
+                Text("Copy data")
+            }
+        },
+        title = { Text(entry.title) },
+        text = {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 400.dp)
+                    .verticalScroll(scrollState)
+            ) {
+                entry.attributes.forEach { (label, value) ->
+                    Text(text = label, style = MaterialTheme.typography.labelMedium)
+                    Text(text = value.ifEmpty { "—" }, style = MaterialTheme.typography.bodyMedium)
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
+            }
+        }
+    )
+}
+
+private data class CustomParam(
+    val id: Int,
+    val key: String = "",
+    val value: String = ""
+)

--- a/android/app/src/main/java/com/xuimanager/app/ui/XuiViewModel.kt
+++ b/android/app/src/main/java/com/xuimanager/app/ui/XuiViewModel.kt
@@ -1,0 +1,267 @@
+package com.xuimanager.app.ui
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.xuimanager.app.data.DisplayEntry
+import com.xuimanager.app.data.LoginResult
+import com.xuimanager.app.data.RenewResult
+import com.xuimanager.app.data.SessionPreferences
+import com.xuimanager.app.data.SessionPreferencesState
+import com.xuimanager.app.data.XuiRepository
+import com.xuimanager.app.data.XuiRepositoryException
+import com.xuimanager.app.data.XuiServiceFactory
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+
+class XuiViewModel(private val preferences: SessionPreferences) : ViewModel() {
+    var uiState by mutableStateOf(XuiUiState())
+        private set
+
+    private var repository: XuiRepository? = null
+    private var isRestoringSession = false
+
+    init {
+        viewModelScope.launch {
+            preferences.data.collectLatest { state ->
+                uiState = uiState.copy(
+                    loginForm = uiState.loginForm.copy(
+                        baseUrl = state.baseUrl,
+                        username = state.username,
+                        enableLogging = state.enableLogging,
+                        rememberSession = state.rememberSession
+                    )
+                )
+                if (!isRestoringSession && state.shouldRestoreSession() && repository == null) {
+                    restoreSession(state)
+                }
+            }
+        }
+    }
+
+    fun login(baseUrl: String, username: String, password: String, enableLogging: Boolean) {
+        viewModelScope.launch {
+            uiState = uiState.copy(isLoading = true, error = null, successMessage = null)
+            try {
+                val service = XuiServiceFactory.create(baseUrl, enableLogging)
+                val repo = XuiRepository(service)
+                val result = repo.login(username, password)
+                repository = repo
+                uiState = uiState.copy(
+                    isLoading = false,
+                    error = null,
+                    loginResult = result,
+                    baseUrl = baseUrl,
+                    successMessage = "Logged in successfully",
+                    loginForm = uiState.loginForm.copy(
+                        baseUrl = baseUrl,
+                        enableLogging = enableLogging,
+                        username = username
+                    )
+                )
+                persistSessionPreferences(baseUrl, username, enableLogging, result)
+                refreshAll()
+            } catch (ex: Exception) {
+                uiState = uiState.copy(isLoading = false, error = ex.message ?: "Unexpected error")
+            }
+        }
+    }
+
+    fun refreshAll() {
+        val repo = repository ?: return
+        viewModelScope.launch {
+            uiState = uiState.copy(isLoading = true, error = null)
+            try {
+                val statusFilter = uiState.subscriptionStatus
+                val channelIdFilter = uiState.channelFilter?.toIntOrNull()
+                val resellersDeferred = async { repo.fetchResellers() }
+                val subscriptionsDeferred = async { repo.fetchSubscriptions(statusFilter) }
+                val usersDeferred = async { repo.fetchOnlineUsers() }
+                val channelsDeferred = async { repo.fetchChannelWatchers(channelIdFilter) }
+                val resellers = resellersDeferred.await()
+                val subscriptions = subscriptionsDeferred.await()
+                val users = usersDeferred.await()
+                val channels = channelsDeferred.await()
+                uiState = uiState.copy(
+                    isLoading = false,
+                    resellers = resellers,
+                    subscriptions = subscriptions,
+                    onlineUsers = users,
+                    channelWatchers = channels,
+                    error = null
+                )
+            } catch (ex: Exception) {
+                uiState = uiState.copy(isLoading = false, error = ex.message ?: "Unable to refresh data")
+            }
+        }
+    }
+
+    fun renewSubscription(subscriptionId: Int, months: Int) {
+        val repo = repository ?: return
+        viewModelScope.launch {
+            uiState = uiState.copy(isRenewing = true, error = null, successMessage = null)
+            try {
+                val result: RenewResult = repo.renewSubscription(subscriptionId, months)
+                uiState = uiState.copy(
+                    isRenewing = false,
+                    successMessage = result.message,
+                    error = null
+                )
+                refreshAll()
+            } catch (ex: Exception) {
+                uiState = uiState.copy(isRenewing = false, error = ex.message ?: "Unable to renew subscription")
+            }
+        }
+    }
+
+    fun updateSubscriptionStatus(status: String?) {
+        uiState = uiState.copy(subscriptionStatus = status?.takeIf { it.isNotBlank() })
+        refreshAll()
+    }
+
+    fun updateChannelFilter(channelId: String?) {
+        uiState = uiState.copy(channelFilter = channelId?.takeIf { it.isNotBlank() })
+        refreshAll()
+    }
+
+    fun runCustomAction(params: Map<String, String>) {
+        val repo = repository ?: return
+        viewModelScope.launch {
+            uiState = uiState.copy(isLoading = true, error = null, successMessage = null)
+            try {
+                val result = repo.runCustomAction(params)
+                uiState = uiState.copy(
+                    isLoading = false,
+                    successMessage = result.message ?: "Action completed",
+                    error = null
+                )
+            } catch (ex: XuiRepositoryException) {
+                uiState = uiState.copy(isLoading = false, error = ex.message)
+            } catch (ex: Exception) {
+                uiState = uiState.copy(isLoading = false, error = ex.message ?: "Failed to run custom action")
+            }
+        }
+    }
+
+    fun logout() {
+        repository?.clearToken()
+        repository = null
+        val form = uiState.loginForm
+        uiState = XuiUiState(loginForm = form)
+        viewModelScope.launch { preferences.clearToken() }
+    }
+
+    fun clearError() {
+        if (uiState.error != null) {
+            uiState = uiState.copy(error = null)
+        }
+    }
+
+    fun clearSuccessMessage() {
+        if (uiState.successMessage != null) {
+            uiState = uiState.copy(successMessage = null)
+        }
+    }
+
+    fun updateBaseUrl(value: String) {
+        updateLoginForm { it.copy(baseUrl = value) }
+    }
+
+    fun updateUsername(value: String) {
+        updateLoginForm { it.copy(username = value) }
+    }
+
+    fun updateLoggingPreference(enabled: Boolean) {
+        updateLoginForm { it.copy(enableLogging = enabled) }
+    }
+
+    fun updateRememberSession(remember: Boolean) {
+        updateLoginForm { it.copy(rememberSession = remember) }
+        viewModelScope.launch { preferences.updateRememberSession(remember) }
+    }
+
+    private fun updateLoginForm(transform: (LoginFormState) -> LoginFormState) {
+        uiState = uiState.copy(loginForm = transform(uiState.loginForm))
+    }
+
+    private fun persistSessionPreferences(
+        baseUrl: String,
+        username: String,
+        enableLogging: Boolean,
+        result: LoginResult
+    ) {
+        val form = uiState.loginForm
+        viewModelScope.launch {
+            preferences.persistLogin(
+                baseUrl = baseUrl,
+                username = username,
+                enableLogging = enableLogging,
+                rememberSession = form.rememberSession,
+                token = if (form.rememberSession) result.token else null,
+                adminId = result.adminId
+            )
+        }
+    }
+
+    private fun restoreSession(prefs: SessionPreferencesState) {
+        isRestoringSession = true
+        viewModelScope.launch {
+            try {
+                uiState = uiState.copy(isLoading = true, error = null, successMessage = null)
+                val service = XuiServiceFactory.create(prefs.baseUrl, prefs.enableLogging)
+                val repo = XuiRepository(service)
+                val token = prefs.token ?: return@launch
+                repo.restoreToken(token)
+                repository = repo
+                val loginResult = LoginResult(
+                    token = token,
+                    adminId = prefs.adminId,
+                    username = prefs.username.ifBlank { null }
+                )
+                uiState = uiState.copy(
+                    isLoading = false,
+                    loginResult = loginResult,
+                    baseUrl = prefs.baseUrl,
+                    successMessage = "Session restored"
+                )
+                refreshAll()
+            } catch (ex: Exception) {
+                repository = null
+                uiState = uiState.copy(isLoading = false, error = ex.message ?: "Failed to restore session")
+                preferences.clearToken()
+            } finally {
+                isRestoringSession = false
+            }
+        }
+    }
+}
+
+data class XuiUiState(
+    val loginForm: LoginFormState = LoginFormState(),
+    val baseUrl: String = "",
+    val loginResult: LoginResult? = null,
+    val resellers: List<DisplayEntry> = emptyList(),
+    val subscriptions: List<DisplayEntry> = emptyList(),
+    val onlineUsers: List<DisplayEntry> = emptyList(),
+    val channelWatchers: List<DisplayEntry> = emptyList(),
+    val subscriptionStatus: String? = null,
+    val channelFilter: String? = null,
+    val isLoading: Boolean = false,
+    val isRenewing: Boolean = false,
+    val error: String? = null,
+    val successMessage: String? = null
+)
+
+data class LoginFormState(
+    val baseUrl: String = "",
+    val username: String = "",
+    val enableLogging: Boolean = false,
+    val rememberSession: Boolean = false
+)
+
+private fun SessionPreferencesState.shouldRestoreSession(): Boolean {
+    return rememberSession && !token.isNullOrBlank() && baseUrl.isNotBlank()
+}

--- a/android/app/src/main/java/com/xuimanager/app/ui/XuiViewModelFactory.kt
+++ b/android/app/src/main/java/com/xuimanager/app/ui/XuiViewModelFactory.kt
@@ -1,0 +1,15 @@
+package com.xuimanager.app.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.xuimanager.app.data.SessionPreferences
+
+class XuiViewModelFactory(private val preferences: SessionPreferences) : ViewModelProvider.Factory {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(XuiViewModel::class.java)) {
+            return XuiViewModel(preferences) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
+    }
+}

--- a/android/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/android/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M54,18c-11.046,0 -20,8.954 -20,20v8h-6a6,6 0 0,0 -6,6v20a6,6 0 0,0 6,6h52a6,6 0 0,0 6,-6v-20a6,6 0 0,0 -6,-6h-6v-8c0,-11.046 -8.954,-20 -20,-20zm0,8c6.627,0 12,5.373 12,12v8h-24v-8c0,-6.627 5.373,-12 12,-12z" />
+    <path
+        android:fillColor="#7C4DFF"
+        android:pathData="M34,64h40v4H34z" />
+    <path
+        android:fillColor="#7C4DFF"
+        android:pathData="M38,72h32v4H38z" />
+</vector>

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/android/app/src/main/res/mipmap/ic_launcher.xml
+++ b/android/app/src/main/res/mipmap/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/android/app/src/main/res/mipmap/ic_launcher_round.xml
+++ b/android/app/src/main/res/mipmap/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/android/app/src/main/res/values-night/themes.xml
+++ b/android/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,3 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.XUIManager" parent="Theme.Material3.DayNight.NoActionBar" />
+</resources>

--- a/android/app/src/main/res/values/ic_launcher_background.xml
+++ b/android/app/src/main/res/values/ic_launcher_background.xml
@@ -1,0 +1,3 @@
+<resources>
+    <color name="ic_launcher_background">#121212</color>
+</resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">XUI Manager</string>
+</resources>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -1,0 +1,5 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.XUIManager" parent="Theme.Material3.DayNight.NoActionBar">
+        <!-- Customize your light theme here. -->
+    </style>
+</resources>

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,0 +1,5 @@
+plugins {
+    id("com.android.application") version "8.1.2" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.10" apply false
+    id("org.jetbrains.kotlin.plugin.serialization") version "1.9.10" apply false
+}

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,4 @@
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+android.useAndroidX=true
+android.enableJetifier=true
+kotlin.code.style=official

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/android/gradlew
+++ b/android/gradlew
@@ -1,0 +1,41 @@
+#!/usr/bin/env sh
+
+##############################################################################
+##
+##  Gradle start up script for UN*X
+##
+##############################################################################
+
+# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+DEFAULT_JVM_OPTS="-Xmx64m -Xms64m"
+
+APP_BASE_NAME=`basename "$0"`
+APP_HOME=`cd "$(dirname "$0")" && pwd`
+
+CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
+
+if [ ! -f "$CLASSPATH" ]; then
+  echo "Gradle wrapper JAR not found at $CLASSPATH. Please run 'gradle wrapper' to generate it." >&2
+  exit 1
+fi
+
+JAVA_HOME=${JAVA_HOME:-}
+if [ -n "$JAVA_HOME" ] ; then
+  if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+    JAVA_EXEC="$JAVA_HOME/jre/sh/java"
+  else
+    JAVA_EXEC="$JAVA_HOME/bin/java"
+  fi
+  if [ ! -x "$JAVA_EXEC" ] ; then
+    echo "ERROR: JAVA_HOME is set to an invalid directory: $JAVA_HOME" >&2
+    exit 1
+  fi
+else
+  JAVA_EXEC=`which java`
+  if [ -z "$JAVA_EXEC" ] ; then
+    echo "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH." >&2
+    exit 1
+  fi
+fi
+
+exec "$JAVA_EXEC" $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS -classpath "$CLASSPATH" org.gradle.wrapper.GradleWrapperMain "$@"

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -1,0 +1,2 @@
+rootProject.name = "XUIManager"
+include(":app")


### PR DESCRIPTION
## Summary
- add a DataStore-backed session preferences store and view model factory so remembered tokens can restore the dashboard automatically
- update the view model and Compose login screen to drive base URL, logging, and remember-session state from shared state and persist it after login
- document the remember-session capability and pull in the DataStore dependency used for the new persistence layer

## Testing
- ./gradlew tasks *(fails: Gradle wrapper JAR is intentionally not checked in)*

------
https://chatgpt.com/codex/tasks/task_e_68e64bd745d0832fb7b84b2ed1dd819c